### PR TITLE
Fixes libs not having sources in dev environments.

### DIFF
--- a/minecraft/artifacts.gradle
+++ b/minecraft/artifacts.gradle
@@ -24,10 +24,18 @@ task deobfJar(type: Jar) {
     classifier = "deobf"
 }
 
+task forgelibJar(type: Jar) {
+    description = 'Creates a compiled JAR which also contains raw sources.'
+    from sourceSets.main.output
+    from sourceSets.main.allJava
+    classifier = 'forgelib'
+}
+
 //Adds the artifact types added by this script to the actual artifacts list. 
 artifacts {
 
     archives sourcesJar
     archives javadocJar
     archives deobfJar
+    archives forgelibJar
 }

--- a/minecraft/maven_nomcp.gradle
+++ b/minecraft/maven_nomcp.gradle
@@ -53,6 +53,10 @@ publishing {
             artifact deobfJar {
                 classifier 'deobf'
             }
+            
+            artifact forgelibJar {
+                classifier 'forgelib'
+            }
         }
     }
 


### PR DESCRIPTION
This PR provides a workaround to an issue with sources introduce in ForgeGradle 3. Due to MCP shenanigans maven can not find the traditional sources artifact. This solves that issue by creating a new artifact with the `forgelib` classifier which includes the sources by default. For this change to take affect the project must first build with this updated script. 

```
compile fg.deobf("net.darkhax.bookshelf:Bookshelf-1.15.2:${bookshelf_version}")
```

becomes

```
compile fg.deobf("net.darkhax.bookshelf:Bookshelf-1.15.2:${bookshelf_version}:forgelib")
```